### PR TITLE
Prints errors in console

### DIFF
--- a/elements/plugins/PurgeSingleFile.php
+++ b/elements/plugins/PurgeSingleFile.php
@@ -59,11 +59,11 @@ if ($skip != 1 && $page_url && $email && $token) {
         if ($result['success'] == 1) {
             $modx->log(MODX_LOG_LEVEL_INFO, 'File cleared from CloudFlare cache: ' . $page_url);
         } else {
-            $modx->log(MODX_LOG_LEVEL_ERROR, 'Cloudflare:' . $result['errors']);
+            $modx->log(MODX_LOG_LEVEL_ERROR, 'Cloudflare:' . print_r($result['errors'],true));
         }
 
         curl_close($ch);
     } else {
-        $modx->log(MODX_LOG_LEVEL_ERROR, 'Cloudflare:' . $result['errors']);
+        $modx->log(MODX_LOG_LEVEL_ERROR, 'Cloudflare:' . print_r($result['errors'],true));
     }
 }


### PR DESCRIPTION
Print array errors
replace Cloudflare:Array to 
Cloudflare:Array
(
    [0] => Array
        (
            [code] => 7003
            [message] => Could not route to /zones/purge_cache, perhaps your object identifier is invalid?
        )

    [1] => Array
        (
            [code] => 7000
            [message] => No route for that URI
        )

)
